### PR TITLE
✨ feat: setDetailWPMs 구현

### DIFF
--- a/MalBal/MalBal/ViewModels/AnalysisViewModel.swift
+++ b/MalBal/MalBal/ViewModels/AnalysisViewModel.swift
@@ -20,104 +20,14 @@ class AnalysisViewModel: ObservableObject {
     @Published var currentTime: Double = 0
     
     @Published var isAnalysisComplete: Bool = false
-    private var transcripts: String = ""
+    var transcripts: [String] = []
+    private var splitURLs: [URL] = []
     
     init(record: Record) {
         self.record = record
     }
     
-    /// 녹음 파일 분석 : STT & set CPM
-    func analyzeRecord() {
-        self.transcribe(url: record.fileURL) { success in
-            if success {
-                self.isAnalysisComplete = true
-                self.setRecordWPM()
-                print(self.transcripts)
-            }
-        }
-    }
-    
-    /// WPM 계산 함수
-    private func setRecordWPM() {
-        let wordCount = Double(transcripts.split(separator: " ").count)
-        
-        guard self.totalTime > 0 else {
-            self.record.wpm = -1
-            return
-        }
-        
-        let wps = wordCount/self.totalTime
-        self.record.wpm = Int(wps * 60)
-    }
-    
-    
-    /// CPM 계산
-    private func setRecordCPM() {
-        
-        if totalTime != 0 {
-            let length = Double(calculateLength(of: transcripts))
-            record.wpm = Int(length / totalTime * 60)
-        } else {
-            print("Error : Record Duration 0")
-        }
-        
-    }
-    
-    
-    /// 글자수 계산 함수
-    private func calculateLength(of text: String?) -> Int {
-        guard let trimmedText = text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-            return 0
-        }
-        
-        // 온점, 느낌표, 쉼표 제거
-        let excludedCharacters = CharacterSet(charactersIn: ".!,")
-        let filteredText = trimmedText.components(separatedBy: excludedCharacters).joined(separator: "")
-        
-        return filteredText.count
-    }
-    
-    /// STT 함수
-    private func transcribe(url: URL, completion: @escaping (Bool) -> Void) {
-        guard let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko_KR")) else {
-            print("Speech recognizer is not available for this locale!")
-            completion(false)
-            return
-        }
-
-        if !speechRecognizer.isAvailable {
-            print("Speech recognizer is not available for this device!")
-            completion(false)
-            return
-        }
-
-        SFSpeechRecognizer.requestAuthorization { authStatus in
-            print(">> transcripts Waits")
-            if (authStatus == .authorized) {
-                let fileURL = url
-                let request = SFSpeechURLRecognitionRequest(url: fileURL)
-                print(">>>### URL: \(fileURL)")
-                
-                let task = speechRecognizer.recognitionTask(
-                    with: request,
-                    resultHandler: { (result, error) in
-                        // MARK: 음성을 차례대로 정확하게 변환하기 위해
-                        if result == nil {
-                            self.transcripts.append("(대화 없음)")
-                            completion(true)
-                        } else if (result?.isFinal)! {
-                            if let res = result?.bestTranscription.formattedString {
-                                self.transcripts.append(res)
-                                print(res)
-                                completion(true)
-                            }
-                        }
-                    })
-            } else {
-                print("Error: Speech-API not authorized!");
-            }
-        }
-    }
+    //MARK: - 음원 재생
     
     // 음원 재생을 토글하는 함수
     func togglePlayer() {
@@ -176,5 +86,174 @@ class AnalysisViewModel: ObservableObject {
         audioPlayer?.stop()
         audioPlayer = nil
     }
+    
+    
+    //MARK: - Wpm 연산
+    /// 전체 WPM 계산 함수
+    func setRecordWPM() {
+        let wordCount = Double(combineTranscripts(transcripts).split(separator: " ").count)
+        
+        guard self.totalTime > 0 else {
+            self.record.wpm = -1
+            return
+        }
+        
+        let wps = wordCount/self.totalTime
+        self.record.wpm = Int(wps * 60)
+    }
+    
+    //MARK: - detailWpms 연산
+    
+    /// 음성파일을 1분단위로 나누어서 transcripts, detailWpms 초기화 함수
+    func setDetailWPMs() {
+        
+        var idx = 0
+        splitURLs = splitAudioFileIntoOneMinuteSegments(audioFileURL: record.fileURL)
+        let numberOfURLs = splitURLs.count
+        
+        loopTransURL(urls: splitURLs, idx: idx, numbersOfURLs: numberOfURLs)
+        
+    }
+    
+    /// 음성파일배열 순회transcribe 
+    private func loopTransURL(urls: [URL], idx: Int, numbersOfURLs: Int) {
+        self.transcribe(url: urls[idx]) { success in
+            if success,
+               idx < numbersOfURLs - 1 {
+                self.loopTransURL(urls: urls, idx: idx+1, numbersOfURLs: numbersOfURLs)
+            } else {
+                print("Transcribing failed for \(urls[idx])")
+                self.isAnalysisComplete = true
+            }
+        }
+    }
+    
+    /// STT 함수
+    private func transcribe(url: URL, completion: @escaping (Bool) -> Void) {
+        guard let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko_KR")) else {
+            print("Speech recognizer is not available for this locale!")
+            completion(false)
+            return
+        }
+
+        if !speechRecognizer.isAvailable {
+            print("Speech recognizer is not available for this device!")
+            completion(false)
+            return
+        }
+
+        SFSpeechRecognizer.requestAuthorization { authStatus in
+            print(">> transcripts Waits")
+            if (authStatus == .authorized) {
+                let fileURL = url
+                let request = SFSpeechURLRecognitionRequest(url: fileURL)
+                print(">>>### URL: \(fileURL)")
+                
+                let task = speechRecognizer.recognitionTask(
+                    with: request,
+                    resultHandler: { (result, error) in
+                        // MARK: 음성을 차례대로 정확하게 변환하기 위해
+                        if result == nil {
+                            self.transcripts.append("(대화 없음)")
+                            completion(true)
+                        } else if (result?.isFinal)! {
+                            if let res = result?.bestTranscription.formattedString {
+                                // 결과 Transcripts 추가
+                                self.transcripts.append(res)
+                                // detail Wpms 추가
+                                self.addDetailWpms(textPerMinute: res)
+                                print(res)
+                                completion(true)
+                            }
+                        }
+                    })
+            } else {
+                print("Error: Speech-API not authorized!");
+            }
+        }
+    }
+    
+    ///  음성 파일 자르기
+    func splitAudioFileIntoOneMinuteSegments(audioFileURL: URL) -> [URL] {
+        var splitURLs: [URL] = []
+        
+        // 오디오 파일 로드
+        let asset = AVURLAsset(url: audioFileURL)
+        
+        // 오디오 파일의 총 재생 시간을 초 단위로 가져오기
+        let totalDuration = CMTimeGetSeconds(asset.duration)
+        
+        // 파일을 저장할 디렉토리를 가져오기
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        
+        // 원본 파일 이름을 기반으로 세그먼트용 파일 이름을 만들기
+        let originalFileName = audioFileURL.lastPathComponent
+        let fileNamePrefix = originalFileName.prefix(upTo: originalFileName.index(originalFileName.endIndex, offsetBy: -4))
+        
+        // 각 세그먼트의 길이를 초 단위로 정의 (1분)
+        let segmentDuration: Double = 60.0
+        
+        // 필요한 세그먼트의 개수를 계산
+        let numberOfSegments = Int(ceil(totalDuration / segmentDuration))
+        
+        // 세그먼트 생성 및 내보내기
+        for segmentIndex in 0..<numberOfSegments {
+            // 현재 세그먼트의 시간 범위를 계산
+            let startTime = CMTime(seconds: Double(segmentIndex) * segmentDuration, preferredTimescale: 1)
+            var endTime = CMTime(seconds: Double(segmentIndex + 1) * segmentDuration, preferredTimescale: 1)
+            
+            // 계산된 종료 시간이 총 재생 시간을 초과하는지 확인
+            if CMTimeCompare(endTime, asset.duration) == 1 {
+                endTime = asset.duration
+            }
+            
+            // 현재 세그먼트에 대한 내보내기 세션을 생성합니다
+            let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A)
+            let outputURL = documentsDirectory.appendingPathComponent("\(fileNamePrefix)_\(segmentIndex).m4a")
+            exportSession?.outputURL = outputURL
+            exportSession?.outputFileType = .m4a
+            exportSession?.timeRange = CMTimeRangeFromTimeToTime(start: startTime, end: endTime)
+            
+            // 내보내기 수행
+            let exportSemaphore = DispatchSemaphore(value: 0)
+            exportSession?.exportAsynchronously(completionHandler: {
+                exportSemaphore.signal()
+            })
+            exportSemaphore.wait()
+            
+            // 내보낸 세그먼트의 URL을 배열에 추가합니다
+            splitURLs.append(outputURL)
+        }
+        
+        return splitURLs
+    }
+    
+    private func addDetailWpms(textPerMinute: String) {
+        self.record.detailWpms.append(calculateWPM(textPerMinute: textPerMinute))
+    }
+    
+    private func calculateWPM(textPerMinute: String) -> Int {
+        let wordCount = textPerMinute.split(separator: " ").count
+        return wordCount
+    }
+    
+    private func combineTranscripts(_ strings: [String], separator: String = "") -> String {
+        return strings.joined(separator: separator)
+    }
+    
+    func clearFiles() {
+        let fileManager = FileManager.default
+        
+        for url in splitURLs {
+            do {
+                try fileManager.removeItem(at: url)
+                print("Deleted file at: \(url)")
+            } catch {
+                print("Error: Deleting file at - \(url), \(error.localizedDescription)")
+            }
+        }
+        print("Completed: Clear Files")
+    }
+    
     
 }

--- a/MalBal/MalBal/Views/Analysis/TestAudioRecorderView.swift
+++ b/MalBal/MalBal/Views/Analysis/TestAudioRecorderView.swift
@@ -164,13 +164,27 @@ struct TestRecordAnalysisView: View {
             
             Text(String(vm.record.wpm))
             
-            Button(action: {
-                vm.togglePlayer()
-            }) {
-                Image(systemName: vm.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                    .resizable()
-                    .frame(width: 75, height: 75)
+            HStack{
+                Spacer()
+                Button {
+                    vm.clearFiles()
+                } label: {
+                    Image(systemName: "trash.circle.fill")
+                        .resizable()
+                        .frame(width: 75, height: 75)
+                }
+                Spacer()
+                Button {
+                    vm.togglePlayer()
+                } label: {
+                    Image(systemName: vm.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .resizable()
+                        .frame(width: 75, height: 75)
+                }
+                Spacer()
+                
             }
+
             
             HStack{
                 Text("구간")
@@ -179,14 +193,14 @@ struct TestRecordAnalysisView: View {
             }
             
             .padding(.horizontal)
-            List(0..<Int(vm.totalTime) / 60, id: \.self) { minute in
+            List(0..<(Int(vm.totalTime) / 60 + 1), id: \.self) { minute in
                 Button(action: {
                     vm.seekToMinute(minute)
                 }) {
                     HStack{
                         Text("\(minute)-\(minute + 1)분")
                         Spacer()
-                        Text("빠름")
+                        Text("\(vm.record.detailWpms.indices.contains(minute) ? vm.record.detailWpms[minute] : -1)")
                     }
                 }
             }
@@ -197,12 +211,18 @@ struct TestRecordAnalysisView: View {
         .padding()
         .onAppear{
             vm.setupAudioPlayer()
-            vm.analyzeRecord()
+            vm.setDetailWPMs()
         }
         .onDisappear(perform: vm.stopAudioPlayer)
         .onReceive(Timer.publish(every: 0.1, on: .main, in: .common).autoconnect(), perform: { _ in
             vm.updatePlaybackTime()
         })
+        .onChange(of: vm.isAnalysisComplete) { newValue in
+            if newValue {
+                vm.setRecordWPM()
+                print(vm.transcripts)
+            }
+        }
     }
     
     // 음원 재생 시간을 포맷하는 함수


### PR DESCRIPTION
## 💡 Related Issue
#15 
Record파일을 1분단위로 잘라서 [URL] 으로 저장하고,
1분단위 파일들을 순회하면서 transcripts&Detailwpms 연산


## 📝 What's-New

AnalysisViewModel 1분단위 WPM 연산 기능 구현 
- [x] setDetailWPMs() : 1분단위 WPM 을 구하고 record.detailWpms에 추가하는 메소드
- [x] splitAudioFileIntoOneMinuteSegments() : record파일을 1분단위로 잘라서 저장하고, 해당 URL들을 반환합니다.
- [x] clearFiles() : splitURLs를 순회하면서 delete 실행
